### PR TITLE
Add a short section about possible size limits of json and jsonb

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -348,6 +348,33 @@ _Generally_ speaking, `jsonb` will make more sense
 
 ---
 
+# Side note
+
+```
+ -------------------------------------------------
+|                     | json   | jsonb            |
+ -------------------------------------------------
+| storage             | text   | optimized parsed |
+|                     |        | binary format    |
+ -------------------------------------------------
+```
+
+Q: You might be asking: what are the size limits of these data types?
+
+A: It's not documented but from SO answers that looked at source code:
+- json is backed by text, so ~1GB 
+- jsonb ~255MB
+
+
+Alt Ans: The reason why it's not in the docs is possibly because if you're inserting such big docs
+into a column, you're probably doing something wrong...
+
+
+(relevant csqw: a record zij pulled was 120k [not very wordy] lines was only ~9MB for scale)
+
+
+---
+
 # Side by side
 
 To make it easier to compare, we'll see use both in our table


### PR DESCRIPTION
Not sure if this is the best place to put it :hmm-parrot:

We might be better off being hand-wavy and saying a blanket statement like:

> Keep json/jsonb documents size to a reasonable amount; if your file size is gigantic, odds are it could have been structured better, i.e. having a column for personId and then the person_record document wholesale would not help things

or maybe reiterate to the early parts of the slides where you mentioned pros of json/jsonb or how to use them effectively?